### PR TITLE
Add sprint-dashboard project entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,11 @@
           <p>GitHub PR analytics dashboard for engineering managers. Tracks merge time, review engagement, and silent approvals.</p>
         </li>
         <li>
+          <a href="https://jira.williamhuang.dev" target="_blank" rel="noopener">sprint-dashboard ↗</a>
+          <span class="tag">passcode locked</span>
+          <p>Sprint productivity tracker for engineering teams. Contains sensitive colleague data — access restricted.</p>
+        </li>
+        <li>
           <span class="project-name">plateful</span>
           <span class="tag">in progress</span>
           <p>Social app for sharing meals with people who care about your health. Mild peer pressure to eat better.</p>


### PR DESCRIPTION
Links to jira.williamhuang.dev with passcode-locked tag, noting it measures sprint productivity and contains sensitive colleague data.

https://claude.ai/code/session_014C2MrVuDJiEVe8AyEDRLFp